### PR TITLE
Remove start command from postCreate

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,7 @@
   // "forwardPorts": [],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "npm install && npm run start",
+  "postCreateCommand": "npm install",
 
   // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "node",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,13 @@
         "esbenp.prettier-vscode",
         "ms-vscode.azure-account",
         "ms-azuretools.vscode-azurestaticwebapps"
-      ]
+      ],
+      "settings": {
+        "emmet.includeLanguages": {
+          "javascript": "javascriptreact"
+        },
+        "emmet.triggerExpansionOnTab": true
+      }
     }
   },
 


### PR DESCRIPTION
Starting a long running process in container life cycle methods will currently lock the port in the background even if you delete the terminal instance.